### PR TITLE
docs: update title and contact info to reflect CEPU branding

### DIFF
--- a/client/index.html
+++ b/client/index.html
@@ -5,7 +5,7 @@
   <meta charset="UTF-8" />
   <link rel="icon" type="image/svg+xml" href="/CEPU.png" />
   <meta name="viewport" content="width=device-width, initial-scale=1.0" />
-  <title>Vite + React + TS</title>
+  <title>CEPU</title>
 </head>
 
 <body>

--- a/server/src/scripts/createPDF.ts
+++ b/server/src/scripts/createPDF.ts
@@ -49,8 +49,8 @@ function getA5ContentWithHeaderFooter(student: StudentData, photo_base_64: strin
 
    const footer = {
       columns: [
-         { text: 'Dirección: Calle Ficticia 123 - Tel: 555-1234', alignment: 'left', fontSize: 9, margin: [10, 10, 0, 0] },
-         { text: 'www.centroejemplo.edu', alignment: 'right', fontSize: 9, margin: [0, 10, 10, 0] }
+         { text: 'Dirección: Av. Los Maestros S/N - Carretera Panamericana Sur km. 300.5 - Tel: (056) 321485', alignment: 'left', fontSize: 9, margin: [10, 10, 0, 0] },
+         { text: 'https://cepu.unica.edu.pe/', alignment: 'right', fontSize: 9, margin: [0, 10, 10, 0] }
       ],
       margin: [0, 10, 0, 0],
    };


### PR DESCRIPTION
Update the page title from generic "Vite + React + TS" to "CEPU" and replace placeholder contact information in PDF footer with actual CEPU address, phone number, and website URL.